### PR TITLE
ignore links prefixed with <

### DIFF
--- a/src/github_text_embed/index.js
+++ b/src/github_text_embed/index.js
@@ -6,7 +6,7 @@ module.exports = client => {
   client.on('messageCreate', async msg => {
     const words = msg.content.split(' ')
     const link = words.find(word => word.includes('https://github.com'))
-    if (link == null || link.startsWith('<') return
+    if (link == null || link.startsWith('<')) return
     const parsed = await parse(link)
     if (parsed === null || parsed.L1 < 0 || parsed.L1 > parsed.L2 || parsed.L1 - 1 > parsed.text.length || parsed.L2 - 1 > parsed.text.length) return
     let [l1, l2] = [0, 0]

--- a/src/github_text_embed/index.js
+++ b/src/github_text_embed/index.js
@@ -7,7 +7,7 @@ module.exports = client => {
     const words = msg.content.split(' ')
     const link = words.find(word => word.includes('https://github.com'))
     if (link == null) return
-    const ignoreLink = const link = words.find(word => word.includes('<https://github.com'))
+    const ignoreLink = words.find(word => word.includes('<https://github.com'))
     if (ignoreLink) return
     const parsed = await parse(link)
     if (parsed === null || parsed.L1 < 0 || parsed.L1 > parsed.L2 || parsed.L1 - 1 > parsed.text.length || parsed.L2 - 1 > parsed.text.length) return

--- a/src/github_text_embed/index.js
+++ b/src/github_text_embed/index.js
@@ -6,9 +6,7 @@ module.exports = client => {
   client.on('messageCreate', async msg => {
     const words = msg.content.split(' ')
     const link = words.find(word => word.includes('https://github.com'))
-    if (link == null) return
-    const ignoreLink = words.find(word => word.includes('<https://github.com'))
-    if (ignoreLink) return
+    if (link == null || link.startsWith('<') return
     const parsed = await parse(link)
     if (parsed === null || parsed.L1 < 0 || parsed.L1 > parsed.L2 || parsed.L1 - 1 > parsed.text.length || parsed.L2 - 1 > parsed.text.length) return
     let [l1, l2] = [0, 0]

--- a/src/github_text_embed/index.js
+++ b/src/github_text_embed/index.js
@@ -7,6 +7,8 @@ module.exports = client => {
     const words = msg.content.split(' ')
     const link = words.find(word => word.includes('https://github.com'))
     if (link == null) return
+    const ignoreLink = const link = words.find(word => word.includes('<https://github.com'))
+    if (ignoreLink) return
     const parsed = await parse(link)
     if (parsed === null || parsed.L1 < 0 || parsed.L1 > parsed.L2 || parsed.L1 - 1 > parsed.text.length || parsed.L2 - 1 > parsed.text.length) return
     let [l1, l2] = [0, 0]


### PR DESCRIPTION
markdown has the option to not show embeds for messages that start with `<` and end with `>`